### PR TITLE
fix: add <script> tag to js asset management

### DIFF
--- a/resources/views/widgets/map-widget.blade.php
+++ b/resources/views/widgets/map-widget.blade.php
@@ -21,6 +21,7 @@
     <x-filament-actions::modals />
 
     {{-- Estilos CSS --}}
+    @push("scripts")
     <style>
         #{{ $mapId }} {
             height: {{ $this->getMapHeight() }}px;
@@ -729,6 +730,7 @@
             window.MapWidget{{ $widgetId }} = MapWidget{{ $widgetId }};
         });
     </script>
+    @endpush
 
     {!! $this->getAdditionalScripts() !!}
 </x-filament-widgets::widget>


### PR DESCRIPTION
I implemented a fix for the issue with "multiple root elements" (see #1)