### PR TITLE
Fix key-value tile servers not working

### DIFF
--- a/src/Concerns/HasMapConfig.php
+++ b/src/Concerns/HasMapConfig.php
@@ -385,7 +385,8 @@ trait HasMapConfig
                 $attribution  = ($layer instanceof TileLayer) ? $layer->getAttribution() : null;
 
                 return [$label, $url, $attribution];
-            })->toArray();
+            })->values()
+            ->toArray();
     }
 
     /**


### PR DESCRIPTION
```
public static function getTileLayersUrl(): TileLayer|string|array
    {
        $mapLayers = MapLayer::query()
            ->pluck('url', 'name');

        return [
            TileLayer::OpenStreetMap,
            TileLayer::EsriWorldStreetMap,
            TileLayer::GoogleTerrain,
            ...$mapLayers->toArray(),
        ];
    }
```
this is not working with the current codebase